### PR TITLE
Provide a way to create and configure AWSGuard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ install:
     - export PATH="$HOME/.pulumi/bin:$PATH"
     # Install toolchain
     - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
-    - yarn global add tslint		
-    - yarn global add typescript
-    - yarn global add mocha
     # Install dependencies
     - make ensure
 script:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build::
 	rm -rf bin/
 
 	# Build
-	tsc --project ./src --outDir ./bin/
+	cd src && yarn run build
 
 	# Set version and copy non-source assets.
 	sed -e 's/\$${VERSION}/$(VERSION)/g' < ./src/package.json > bin/package.json
@@ -26,10 +26,10 @@ build::
 
 .PHONY: lint
 lint::
-	tslint -c ./src/tslint.json -p ./src/tsconfig.json
+	cd src && yarn run lint
 
 test_fast::
-	cd src && mocha --require ./node_modules/ts-node/register tests/**/*.spec.ts
+	cd src && yarn run test
 
 .PHONY: test_all
 test_all::

--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -1,3 +1,0 @@
-name: pulumi-awsguard
-description: A policy pack of rules to enforce AWS best practices for security, reliability, cost, and more
-runtime: nodejs

--- a/integration-tests/compute/index.ts
+++ b/integration-tests/compute/index.ts
@@ -58,6 +58,7 @@ let elbV2Args: aws.elasticloadbalancingv2.LoadBalancerArgs = {
         enabled: true,
         bucket: elbBucket.arn,
     },
+    enableDeletionProtection: true,
 };
 
 let albArgs: aws.applicationloadbalancing.LoadBalancerArgs = {
@@ -65,6 +66,7 @@ let albArgs: aws.applicationloadbalancing.LoadBalancerArgs = {
         enabled: true,
         bucket: elbBucket.arn,
     },
+    enableDeletionProtection: true,
 };
 
 switch (testScenario) {
@@ -110,8 +112,12 @@ switch (testScenario) {
     case 5:
         // Elastic Load Balancers do not have access logs specified.
         elbArgs = { listeners: [] };
-        elbV2Args = {};
-        albArgs = {};
+        elbV2Args = {
+            enableDeletionProtection: true,
+        };
+        albArgs = {
+            enableDeletionProtection: true,
+        };
         break;
     case 6:
         // No EBS volume attached to EC2 instance.

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -96,6 +96,8 @@ func runPolicyPackIntegrationTest(
 
 			e.RunCommand("pulumi", "config", "set", "scenario", fmt.Sprintf("%d", idx+1))
 
+			os.Setenv("PULUMI_AWSGUARD_TESTING", "true")
+
 			if len(scenario.WantErrors) == 0 {
 				t.Log("No errors are expected.")
 				e.RunCommand("pulumi", "preview", "--policy-pack", policyPackDir)

--- a/src/awsGuard.ts
+++ b/src/awsGuard.ts
@@ -1,0 +1,184 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+    EnforcementLevel,
+    Policies,
+    PolicyPack,
+    ResourceValidationPolicy,
+    StackValidationPolicy,
+} from "@pulumi/policy";
+
+import { defaultEnforcementLevel, isEnforcementLevel } from "./enforcementLevel";
+
+const defaultPolicyPackName = "pulumi-awsguard";
+
+// Internal map that holds all the registered policy factories.
+const factoryMap: Record<string, PolicyFactory<any>> = {};
+
+/**
+ * A policy pack of rules to enforce AWS best practices for security, reliability, cost, and more!
+ *
+ * Create an instance of AwsGuard without any arguments to enable all policies with their default configuration:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard();
+ * ```
+ *
+ * The above is equivalent to:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({ all: "mandatory" });
+ * ```
+ *
+ * To make all policies advisory rather than mandatory:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({ all: "advisory" });
+ * ```
+ *
+ * To make all policies advisory, but changing a couple to be mandatory:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({
+ *     all: "advisory",
+ *     ec2InstanceNoPublicIP: "mandatory",
+ *     elbAccessLoggingEnabled: "mandatory",
+ * });
+ * ```
+ *
+ * To disable a particular policy:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({
+ *     ec2InstanceNoPublicIP: "disabled",
+ * });
+ * ```
+ *
+ * To disable all policies except ones explicitly enabled:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({
+ *     all: "disabled",
+ *     ec2InstanceNoPublicIP: "mandatory",
+ *     elbAccessLoggingEnabled: "mandatory",
+ * });
+ * ```
+ *
+ * To specify configuration for policies that have it:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({
+ *     ec2VolumeInUseCheck: { enforcementLevel: "mandatory", checkDeletion: false },
+ *     encryptedVolumes: { enforcementLevel: "mandatory", kmsId: "id" },
+ * });
+ * ```
+ */
+export class AwsGuard extends PolicyPack {
+    constructor(args?: AwsGuardArgs);
+    constructor(name: string, args?: AwsGuardArgs);
+    constructor(nameOrArgs?: string | AwsGuardArgs, args?: AwsGuardArgs) {
+        const [n, a] = getNameAndArgs(nameOrArgs, args);
+        super(n, { policies: getPolicies(factoryMap, a) });
+    }
+}
+
+/**
+ * Argument bag for configuring AwsGuard policies.
+ */
+// Mixins will be applied to this interface in each module that adds a property to
+// configure each policy.
+export interface AwsGuardArgs {
+    all?: EnforcementLevel;
+}
+
+/** @internal */
+export type PolicyFactory<TArgs> = (args?: TArgs) => ResourceValidationPolicy | StackValidationPolicy;
+
+/** @internal */
+export function registerPolicy<K extends keyof AwsGuardArgs>(
+    property: Exclude<K, "all">,
+    factory: PolicyFactory<AwsGuardArgs[K]>): void {
+
+    if (typeof factory !== "function") {
+        throw new Error("'factory' must be a function.");
+    }
+    if (property === "all") {
+        throw new Error("'all' is reserved.");
+    }
+    if (property in factoryMap) {
+        throw new Error(`${property} already exists.`);
+    }
+    factoryMap[property] = factory;
+}
+
+/**
+ * Testable helper to get the name and args from the parameters,
+ * for use in the policy pack's constructor.
+ * @internal
+ */
+export function getNameAndArgs(
+    nameOrArgs?: string | AwsGuardArgs,
+    args?: AwsGuardArgs): [string, AwsGuardArgs | undefined] {
+
+    let name = defaultPolicyPackName;
+    if (typeof nameOrArgs === "string") {
+        name = nameOrArgs;
+    } else if (typeof nameOrArgs === "object") {
+        args = nameOrArgs;
+    }
+    return [name, args];
+}
+
+/**
+ * Generates the array of policies based on the specified args.
+ * @internal
+ */
+export function getPolicies(factories: Record<string, PolicyFactory<any>>, args?: AwsGuardArgs): Policies {
+    // If `args` is falsy or empty, enable all policies with the default enforcement level.
+    if (!args || Object.keys(args).length === 0) {
+        args = { all: defaultEnforcementLevel };
+    }
+    // If `all` isn't set explicitly, clone `args` and set it to the default enforcement level.
+    if (!args.all) {
+        args = Object.assign({}, args);
+        args.all = defaultEnforcementLevel;
+    }
+
+    const policies: Policies = [];
+
+    const keys = Object.keys(factories).sort();
+    for (const key of keys) {
+        const factory = factories[key];
+
+        let factoryArgs: any = undefined;
+        if (args.hasOwnProperty(key)) {
+            factoryArgs = (<Record<string, any>>args)[key];
+        }
+        if (!factoryArgs) {
+            factoryArgs = args.all;
+        }
+
+        // If the policy is disabled, skip it.
+        if (isEnforcementLevel(factoryArgs) && factoryArgs === "disabled") {
+            continue;
+        }
+
+        const policy = factory(factoryArgs);
+        policies.push(policy);
+    }
+
+    // Filter out any disabled policies.
+    return policies.filter(p => p.enforcementLevel !== "disabled");
+}

--- a/src/awsGuard.ts
+++ b/src/awsGuard.ts
@@ -39,22 +39,22 @@ const factoryMap: Record<string, PolicyFactory<any>> = {};
  * The above is equivalent to:
  *
  * ```typescript
- * const awsGuard = new AwsGuard({ all: "mandatory" });
- * ```
- *
- * To make all policies advisory rather than mandatory:
- *
- * ```typescript
  * const awsGuard = new AwsGuard({ all: "advisory" });
  * ```
  *
- * To make all policies advisory, but changing a couple to be mandatory:
+ * To make all policies mandatory rather than advisory:
+ *
+ * ```typescript
+ * const awsGuard = new AwsGuard({ all: "mandatory" });
+ * ```
+ *
+ * To make all policies mandatory, but change a couple to be advisory:
  *
  * ```typescript
  * const awsGuard = new AwsGuard({
- *     all: "advisory",
- *     ec2InstanceNoPublicIP: "mandatory",
- *     elbAccessLoggingEnabled: "mandatory",
+ *     all: "mandatory",
+ *     ec2InstanceNoPublicIP: "advisory",
+ *     elbAccessLoggingEnabled: "advisory",
  * });
  * ```
  *
@@ -80,8 +80,10 @@ const factoryMap: Record<string, PolicyFactory<any>> = {};
  *
  * ```typescript
  * const awsGuard = new AwsGuard({
- *     ec2VolumeInUseCheck: { enforcementLevel: "mandatory", checkDeletion: false },
+ *     ec2VolumeInUseCheck: { checkDeletion: false },
  *     encryptedVolumes: { enforcementLevel: "mandatory", kmsId: "id" },
+ *     redshiftClusterMaintenanceSettingsCheck: { preferredMaintenanceWindow: "Mon:09:30-Mon:10:00" },
+ *     acmCheckCertificateExpiration: { maxDaysUntilExpiration: 10 },
  * });
  * ```
  */
@@ -97,10 +99,9 @@ export class AwsGuard extends PolicyPack {
 /**
  * Argument bag for configuring AwsGuard policies.
  */
-// Mixins will be applied to this interface in each module that adds a property to
-// configure each policy.
 export interface AwsGuardArgs {
     all?: EnforcementLevel;
+    // Note: Properties to configure each policy are added to this interface (mixins) by each module.
 }
 
 /** @internal */

--- a/src/enforcementLevel.ts
+++ b/src/enforcementLevel.ts
@@ -1,0 +1,37 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EnforcementLevel } from "@pulumi/policy";
+
+/** @internal */
+export const defaultEnforcementLevel: EnforcementLevel = "mandatory";
+
+/** @internal */
+export function isEnforcementLevel(o: any): o is EnforcementLevel {
+    // Ensures all possible values are covered in the switch below.
+    const exhaustiveFalse = (_: never) => false;
+
+    if (typeof o === "string") {
+        const enforcementLevel = <EnforcementLevel>o;
+        switch (enforcementLevel) {
+            case "advisory":
+            case "disabled":
+            case "mandatory":
+                return true;
+            default:
+                return exhaustiveFalse(enforcementLevel);
+        }
+    }
+    return false;
+}

--- a/src/enforcementLevel.ts
+++ b/src/enforcementLevel.ts
@@ -15,7 +15,7 @@
 import { EnforcementLevel } from "@pulumi/policy";
 
 /** @internal */
-export const defaultEnforcementLevel: EnforcementLevel = "mandatory";
+export const defaultEnforcementLevel: EnforcementLevel = "advisory";
 
 /** @internal */
 export function isEnforcementLevel(o: any): o is EnforcementLevel {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,8 @@ import "./security";
 import "./storage";
 
 export { AwsGuard, AwsGuardArgs };
+
+// If we're running our integration tests, create a new instance of AwsGuard.
+if (process.env["PULUMI_AWSGUARD_TESTING"] === "true") {
+    const awsGuard = new AwsGuard();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import "./storage";
 export { AwsGuard, AwsGuardArgs };
 
 // If we're running our integration tests, create a new instance of AwsGuard.
+// TODO[pulumi/pulumi-awsguard#34] Use an alternative approach to creating a new instance of AwsGuard
+// for the integration tests, rather than having this baked into the library itself.
 if (process.env["PULUMI_AWSGUARD_TESTING"] === "true") {
-    const awsGuard = new AwsGuard();
+    const awsGuard = new AwsGuard({ all: "mandatory" });
 }

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
     "repository": "https://github.com/pulumi/pulumi-awsguard",
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/policy": "^0.2.0",
+        "@pulumi/policy": "0.2.1-dev.1574701641",
         "@pulumi/pulumi": "^1.0.0",
         "aws-sdk": "^2.545.0"
     },

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,10 @@
     "version": "${VERSION}",
     "description": "Pulumi CrossGuard policies for AWS.",
     "license": "Apache-2.0",
-    "keywords": ["pulumi", "policy"],
+    "keywords": [
+        "pulumi",
+        "policy"
+    ],
     "homepage": "https://www.pulumi.com",
     "repository": "https://github.com/pulumi/pulumi-awsguard",
     "dependencies": {
@@ -21,6 +24,12 @@
         "mocha": "^6.2.1",
         "nyc": "^14.1.1",
         "ts-node": "^8.4.1",
+        "tslint": "^5.20.1",
         "typescript": "^3.6.4"
+    },
+    "scripts": {
+        "build": "tsc",
+        "lint": "tslint -c tslint.json -p tsconfig.json",
+        "test": "mocha --require ./node_modules/ts-node/register tests/**/*.spec.ts"
     }
 }

--- a/src/policyArgs.ts
+++ b/src/policyArgs.ts
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { AwsGuard, AwsGuardArgs } from "./awsGuard";
+import { EnforcementLevel } from "@pulumi/policy";
 
-// Import each area to add AwsGuardArgs mixins and register policies.
-import "./compute";
-import "./database";
-import "./elasticsearch";
-import "./security";
-import "./storage";
-
-export { AwsGuard, AwsGuardArgs };
+export interface PolicyArgs {
+    /** The enforcement level to enforce this policy with. */
+    enforcementLevel?: EnforcementLevel;
+}

--- a/src/security.ts
+++ b/src/security.ts
@@ -58,10 +58,8 @@ export interface AcmCheckCertificateExpirationArgs extends PolicyArgs {
 export function acmCheckCertificateExpiration(args?: EnforcementLevel | AcmCheckCertificateExpirationArgs): StackValidationPolicy {
     const { enforcementLevel, maxDaysUntilExpiration } = getValueOrDefault(args, {
         enforcementLevel: defaultEnforcementLevel,
+        maxDaysUntilExpiration: 14,
     });
-    const maxDays = maxDaysUntilExpiration === undefined
-        ? 14
-        : maxDaysUntilExpiration;
 
     return {
         name: "acm-certificate-expiration",
@@ -78,7 +76,7 @@ export function acmCheckCertificateExpiration(args?: EnforcementLevel | AcmCheck
                     let daysUntilExpiry = (certDescription.NotAfter.getTime() - Date.now()) / msInDay;
                     daysUntilExpiry = Math.floor(daysUntilExpiry);
 
-                    if (daysUntilExpiry < maxDays) {
+                    if (daysUntilExpiry < maxDaysUntilExpiration!) {
                         reportViolation(`certificate expires in ${daysUntilExpiry} (max allowed ${maxDaysUntilExpiration} days)`);
                     }
                 }
@@ -110,12 +108,10 @@ export interface IamAccessKeysRotatedArgs extends PolicyArgs {
 export function iamAccessKeysRotated(args?: EnforcementLevel | IamAccessKeysRotatedArgs): StackValidationPolicy {
     const { enforcementLevel, maxKeyAge } = getValueOrDefault(args, {
         enforcementLevel: defaultEnforcementLevel,
+        maxKeyAge: 90,
     });
-    const maxAge = maxKeyAge === undefined
-        ? 90
-        : maxKeyAge;
 
-    if (maxAge < 1 || maxAge > 2 * 365) {
+    if (maxKeyAge! < 1 || maxKeyAge! > 2 * 365) {
         throw new Error("Invalid maxKeyAge.");
     }
 
@@ -141,7 +137,7 @@ export function iamAccessKeysRotated(args?: EnforcementLevel | IamAccessKeysRota
                         if (accessKey.AccessKeyId === instance.id && accessKey.CreateDate) {
                             let daysSinceCreated = (Date.now() - accessKey.CreateDate!.getTime()) / msInDay;
                             daysSinceCreated = Math.floor(daysSinceCreated);
-                            if (daysSinceCreated > maxAge) {
+                            if (daysSinceCreated > maxKeyAge!) {
                                 reportViolation(`access key must be rotated within ${maxKeyAge} days (key is ${daysSinceCreated} days old)`);
                             }
                         }

--- a/src/security.ts
+++ b/src/security.ts
@@ -17,7 +17,7 @@ import * as AWS from "aws-sdk";
 import * as aws from "@pulumi/aws";
 
 import {
-    EnforcementLevel, Policies, ReportViolation, ResourceValidationPolicy,
+    EnforcementLevel, ReportViolation, ResourceValidationPolicy,
     StackValidation, StackValidationArgs, StackValidationPolicy,
     validateTypedResource,
 } from "@pulumi/policy";
@@ -25,22 +25,49 @@ import {
 import { Resource } from "@pulumi/pulumi";
 import * as q from "@pulumi/pulumi/queryable";
 
+import { registerPolicy } from "./awsGuard";
+import { defaultEnforcementLevel } from "./enforcementLevel";
+import { PolicyArgs } from "./policyArgs";
+import { getValueOrDefault } from "./util";
+
+// Mixin additional properties onto AwsGuardArgs.
+declare module "./awsGuard" {
+    interface AwsGuardArgs {
+        acmCheckCertificateExpiration?: EnforcementLevel | AcmCheckCertificateExpirationArgs;
+        cmkBackingKeyRotationEnabled?: EnforcementLevel;
+        iamAccessKeysRotated?: EnforcementLevel | IamAccessKeysRotatedArgs;
+        iamMfaEnabledForConsoleAccess?: EnforcementLevel;
+    }
+}
+
+// Register policy factories.
+registerPolicy("acmCheckCertificateExpiration", acmCheckCertificateExpiration);
+registerPolicy("cmkBackingKeyRotationEnabled", cmkBackingKeyRotationEnabled);
+registerPolicy("iamAccessKeysRotated", iamAccessKeysRotated);
+registerPolicy("iamMfaEnabledForConsoleAccess", iamMfaEnabledForConsoleAccess);
+
 // Milliseconds in a day.
 const msInDay = 24 * 60 * 60 * 1000;
 
-export const security: Policies = [
-    acmCheckCertificateExpiration("mandatory", 14 /* max days before certificate expires */),
-    cmkBackingKeyRotationEnabled("mandatory"),
-    iamAccessKeysRotated("mandatory", 90 /* max key age in days */),
-    iamMfaEnabledForConsoleAccess("mandatory"),
-];
+export interface AcmCheckCertificateExpirationArgs extends PolicyArgs {
+    /** Max days before certificate expires. Defaults to 14. */
+    maxDaysUntilExpiration?: number;
+}
 
-export function acmCheckCertificateExpiration(enforcementLevel: EnforcementLevel = "advisory", maxDaysUntilExpiration: number): StackValidationPolicy {
+/** @internal */
+export function acmCheckCertificateExpiration(args?: EnforcementLevel | AcmCheckCertificateExpirationArgs): StackValidationPolicy {
+    const { enforcementLevel, maxDaysUntilExpiration } = getValueOrDefault(args, {
+        enforcementLevel: defaultEnforcementLevel,
+    });
+    const maxDays = maxDaysUntilExpiration === undefined
+        ? 14
+        : maxDaysUntilExpiration;
+
     return {
         name: "acm-certificate-expiration",
         description: "Checks whether an ACM certificate has expired. Certificates provided by ACM are automatically renewed. ACM does not automatically renew certificates that you import.",
         enforcementLevel: enforcementLevel,
-        validateStack: validateTypedResources(aws.acm.Certificate.isInstance, async (acmCertificates, args, reportViolation) => {
+        validateStack: validateTypedResources(aws.acm.Certificate.isInstance, async (acmCertificates, _, reportViolation) => {
             const acm = new AWS.ACM();
             // Fetch the full ACM certificate using the AWS SDK to get its expiration date.
             for (const certInStack of acmCertificates) {
@@ -51,7 +78,7 @@ export function acmCheckCertificateExpiration(enforcementLevel: EnforcementLevel
                     let daysUntilExpiry = (certDescription.NotAfter.getTime() - Date.now()) / msInDay;
                     daysUntilExpiry = Math.floor(daysUntilExpiry);
 
-                    if (daysUntilExpiry < maxDaysUntilExpiration) {
+                    if (daysUntilExpiry < maxDays) {
                         reportViolation(`certificate expires in ${daysUntilExpiry} (max allowed ${maxDaysUntilExpiration} days)`);
                     }
                 }
@@ -60,12 +87,13 @@ export function acmCheckCertificateExpiration(enforcementLevel: EnforcementLevel
     };
 }
 
-export function cmkBackingKeyRotationEnabled(enforcementLevel: EnforcementLevel = "advisory"): ResourceValidationPolicy {
+/** @internal */
+export function cmkBackingKeyRotationEnabled(enforcementLevel?: EnforcementLevel): ResourceValidationPolicy {
     return {
         name: "cmk-backing-key-rotation-enabled",
         description: "Checks that key rotation is enabled for each customer master key (CMK). Checks that key rotation is enabled for specific key object. Does not apply to CMKs that have imported key material.",
-        enforcementLevel: enforcementLevel,
-        validateResource: validateTypedResource(aws.kms.Key, async (instance, args, reportViolation) => {
+        enforcementLevel: enforcementLevel || defaultEnforcementLevel,
+        validateResource: validateTypedResource(aws.kms.Key, async (instance, _, reportViolation) => {
             if (!instance.enableKeyRotation) {
                 reportViolation("CMK does not have the key rotation setting enabled");
             }
@@ -73,8 +101,21 @@ export function cmkBackingKeyRotationEnabled(enforcementLevel: EnforcementLevel 
     };
 }
 
-export function iamAccessKeysRotated(enforcementLevel: EnforcementLevel = "advisory", maxKeyAge: number): StackValidationPolicy {
-    if (maxKeyAge < 1 || maxKeyAge > 2 * 365) {
+export interface IamAccessKeysRotatedArgs extends PolicyArgs {
+    /** Max key age in days. Defaults to 90. */
+    maxKeyAge?: number;
+}
+
+/** @internal */
+export function iamAccessKeysRotated(args?: EnforcementLevel | IamAccessKeysRotatedArgs): StackValidationPolicy {
+    const { enforcementLevel, maxKeyAge } = getValueOrDefault(args, {
+        enforcementLevel: defaultEnforcementLevel,
+    });
+    const maxAge = maxKeyAge === undefined
+        ? 90
+        : maxKeyAge;
+
+    if (maxAge < 1 || maxAge > 2 * 365) {
         throw new Error("Invalid maxKeyAge.");
     }
 
@@ -82,7 +123,7 @@ export function iamAccessKeysRotated(enforcementLevel: EnforcementLevel = "advis
         name: "access-keys-rotated",
         description: "Checks whether an access key have been rotated within maxKeyAge days.",
         enforcementLevel: enforcementLevel,
-        validateStack: validateTypedResources(aws.iam.AccessKey.isInstance, async (accessKeys, args, reportViolation) => {
+        validateStack: validateTypedResources(aws.iam.AccessKey.isInstance, async (accessKeys, _, reportViolation) => {
             const iam = new AWS.IAM();
             for (const instance of accessKeys) {
                 // Skip any access keys that haven't yet been provisioned or whose status is inactive.
@@ -100,7 +141,7 @@ export function iamAccessKeysRotated(enforcementLevel: EnforcementLevel = "advis
                         if (accessKey.AccessKeyId === instance.id && accessKey.CreateDate) {
                             let daysSinceCreated = (Date.now() - accessKey.CreateDate!.getTime()) / msInDay;
                             daysSinceCreated = Math.floor(daysSinceCreated);
-                            if (daysSinceCreated > maxKeyAge) {
+                            if (daysSinceCreated > maxAge) {
                                 reportViolation(`access key must be rotated within ${maxKeyAge} days (key is ${daysSinceCreated} days old)`);
                             }
                         }
@@ -113,12 +154,13 @@ export function iamAccessKeysRotated(enforcementLevel: EnforcementLevel = "advis
     };
 }
 
-export function iamMfaEnabledForConsoleAccess(enforcementLevel: EnforcementLevel = "advisory"): ResourceValidationPolicy {
+/** @internal */
+export function iamMfaEnabledForConsoleAccess(enforcementLevel?: EnforcementLevel): ResourceValidationPolicy {
     return {
         name: "mfa-enabled-for-iam-console-access",
         description: "Checks whether multi-factor Authentication (MFA) is enabled for an IAM user that use a console password.",
-        enforcementLevel: enforcementLevel,
-        validateResource: validateTypedResource(aws.iam.UserLoginProfile, async (instance, args, reportViolation) => {
+        enforcementLevel: enforcementLevel || defaultEnforcementLevel,
+        validateResource: validateTypedResource(aws.iam.UserLoginProfile, async (instance, _, reportViolation) => {
             const iam = new AWS.IAM();
             const mfaDevicesResp = await iam.listMFADevices({ UserName: instance.user }).promise();
             // We don't bother with paging through all MFA devices, since we only check that there is at least one.

--- a/src/tests/awsGuard.spec.ts
+++ b/src/tests/awsGuard.spec.ts
@@ -1,0 +1,188 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+
+import "mocha";
+
+import { EnforcementLevel, Policies } from "@pulumi/policy";
+
+import { AwsGuardArgs, getNameAndArgs, getPolicies, PolicyFactory } from "../awsGuard";
+import * as compute from "../compute";
+
+// Make mixins available.
+import "../index";
+
+type Expected = { name: string, enforcementLevel: EnforcementLevel };
+
+describe("#AwsGuard", () => {
+    describe("getNameAndArgs", () => {
+        it("returns the expected values for the inputs", () => {
+            const defaultName = "pulumi-awsguard";
+            assert.deepStrictEqual(getNameAndArgs(), [defaultName, undefined]);
+            assert.deepStrictEqual(getNameAndArgs("hi"), ["hi", undefined]);
+            assert.deepStrictEqual(getNameAndArgs({}), [defaultName, {}]);
+            assert.deepStrictEqual(getNameAndArgs({ all: "advisory" }), [defaultName, { all: "advisory" }]);
+            assert.deepStrictEqual(
+                getNameAndArgs({ ec2VolumeInUseCheck: "advisory" }),
+                [defaultName, { ec2VolumeInUseCheck: "advisory" }]);
+            assert.deepStrictEqual(
+                getNameAndArgs({ ec2VolumeInUseCheck: { checkDeletion: true } }),
+                [defaultName, { ec2VolumeInUseCheck: { checkDeletion: true } }]);
+            assert.deepStrictEqual(getNameAndArgs("hi", {}), ["hi", {}]);
+            assert.deepStrictEqual(getNameAndArgs("hi", { all: "advisory" }), ["hi", { all: "advisory" }]);
+            assert.deepStrictEqual(
+                getNameAndArgs(undefined, { all: "mandatory" }),
+                [defaultName, { all: "mandatory" }]);
+            assert.deepStrictEqual(getNameAndArgs({}, { all: "disabled" }), [defaultName, {}]);
+        });
+    });
+
+    describe("getPolicies", () => {
+        const defaultEnforcementLevel: EnforcementLevel = "mandatory";
+
+        const factories: Record<string, PolicyFactory<any>> = {
+            ec2InstanceDetailedMonitoringEnabled: compute.ec2InstanceDetailedMonitoringEnabled,
+            ec2InstanceNoPublicIP: compute.ec2InstanceNoPublicIP,
+            ec2VolumeInUseCheck: compute.ec2VolumeInUseCheck,
+            elbAccessLoggingEnabled: compute.elbAccessLoggingEnabled,
+            encryptedVolumes: compute.encryptedVolumes,
+        };
+
+        const createExpected = (enforcementLevel: EnforcementLevel) => [
+            { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel },
+            { name: "ec2-instance-no-public-ip", enforcementLevel },
+            { name: "ec2-volume-inuse-check", enforcementLevel },
+            { name: "elb-logging-enabled", enforcementLevel },
+            { name: "encrypted-volumes", enforcementLevel },
+        ];
+
+        it("returns all policies with the default enforcement level for undefined, null, empty, and args with undefined or null all", () => {
+            const expected = createExpected(defaultEnforcementLevel);
+            assertPoliciesEqual(getPolicies(factories, undefined), expected);
+            assertPoliciesEqual(getPolicies(factories, <AwsGuardArgs><unknown>null), expected);
+            assertPoliciesEqual(getPolicies(factories, {}), expected);
+            assertPoliciesEqual(getPolicies(factories, { all: undefined }), expected);
+            assertPoliciesEqual(getPolicies(factories, { all: <EnforcementLevel><unknown>null }), expected);
+        });
+
+        it("returns all policies with the specified enforcement level in the all arg", () => {
+            assertPoliciesEqual(getPolicies(factories, { all: "advisory" }), createExpected("advisory"));
+            assertPoliciesEqual(getPolicies(factories, { all: "mandatory" }), createExpected("mandatory"));
+        });
+
+        it("returns no policies when all is set to disabled", () => {
+            const actual = getPolicies(factories, { all: "disabled" });
+            assert.strictEqual(actual.length, 0);
+        });
+
+        it("returns all policies except those that are explicitly disabled", () => {
+            const expected: Expected[] = [
+                { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel: defaultEnforcementLevel },
+                { name: "elb-logging-enabled", enforcementLevel: defaultEnforcementLevel },
+                { name: "encrypted-volumes", enforcementLevel: defaultEnforcementLevel },
+            ];
+            const actual = getPolicies(factories, {
+                ec2InstanceNoPublicIP: "disabled",
+                ec2VolumeInUseCheck: "disabled",
+            });
+            assertPoliciesEqual(actual, expected);
+        });
+
+        it("returns all policies except those that are explicitly disabled through args", () => {
+            const expected: Expected[] = [
+                { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel: defaultEnforcementLevel },
+                { name: "ec2-instance-no-public-ip", enforcementLevel: defaultEnforcementLevel },
+                { name: "elb-logging-enabled", enforcementLevel: defaultEnforcementLevel },
+            ];
+            const actual = getPolicies(factories, {
+                ec2VolumeInUseCheck: { enforcementLevel: "disabled" },
+                encryptedVolumes: { enforcementLevel: "disabled" },
+            });
+            assertPoliciesEqual(actual, expected);
+        });
+
+        it("returns policies that are explicitly enabled", () => {
+            const expected: Expected[] = [
+                { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel: "mandatory" },
+                { name: "encrypted-volumes", enforcementLevel: "advisory" },
+            ];
+            const actual = getPolicies(factories, {
+                all: "disabled",
+                ec2InstanceDetailedMonitoringEnabled: "mandatory",
+                encryptedVolumes: "advisory",
+            });
+            assertPoliciesEqual(actual, expected);
+        });
+
+        it("returns all policies set to advisory with one set to mandatory", () => {
+            const expected: Expected[] = [
+                { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel: "advisory" },
+                { name: "ec2-instance-no-public-ip", enforcementLevel: "advisory" },
+                { name: "ec2-volume-inuse-check", enforcementLevel: "advisory" },
+                { name: "elb-logging-enabled", enforcementLevel: "mandatory" },
+                { name: "encrypted-volumes", enforcementLevel: "advisory" },
+            ];
+            const actual = getPolicies(factories, {
+                all: "advisory",
+                elbAccessLoggingEnabled: "mandatory",
+            });
+            assertPoliciesEqual(actual, expected);
+        });
+
+        it("returns all policies set to advisory with one set to mandatory through args", () => {
+            const expected: Expected[] = [
+                { name: "ec2-instance-detailed-monitoring-enabled", enforcementLevel: "advisory" },
+                { name: "ec2-instance-no-public-ip", enforcementLevel: "advisory" },
+                { name: "ec2-volume-inuse-check", enforcementLevel: "mandatory" },
+                { name: "elb-logging-enabled", enforcementLevel: "advisory" },
+                { name: "encrypted-volumes", enforcementLevel: "advisory" },
+            ];
+            assertPoliciesEqual(getPolicies(factories, {
+                all: "advisory",
+                ec2VolumeInUseCheck: { enforcementLevel: "mandatory" },
+            }), expected);
+            assertPoliciesEqual(getPolicies(factories, {
+                all: "advisory",
+                ec2VolumeInUseCheck: { enforcementLevel: "mandatory", checkDeletion: true },
+            }), expected);
+        });
+
+        it("returns policies that are explicitly enabled through args", () => {
+            const expected: Expected[] = [
+                { name: "ec2-volume-inuse-check", enforcementLevel: "advisory" },
+                { name: "encrypted-volumes", enforcementLevel: "mandatory" },
+            ];
+            assertPoliciesEqual(getPolicies(factories, {
+                all: "disabled",
+                ec2VolumeInUseCheck: { enforcementLevel: "advisory" },
+                encryptedVolumes: { enforcementLevel: "mandatory" },
+            }), expected);
+            assertPoliciesEqual(getPolicies(factories, {
+                all: "disabled",
+                ec2VolumeInUseCheck: { enforcementLevel: "advisory", checkDeletion: true },
+                encryptedVolumes: { enforcementLevel: "mandatory", kmsId: "id" },
+            }), expected);
+        });
+    });
+});
+
+function assertPoliciesEqual(actual: Policies, expected: Expected[]) {
+    assert.strictEqual(actual.length, expected.length);
+
+    for (let i = 0; i < actual.length; i++) {
+        assert.strictEqual(actual[i].name, expected[i].name);
+        assert.strictEqual(actual[i].enforcementLevel, expected[i].enforcementLevel);
+    }
+}

--- a/src/tests/awsGuard.spec.ts
+++ b/src/tests/awsGuard.spec.ts
@@ -50,7 +50,7 @@ describe("#AwsGuard", () => {
     });
 
     describe("getPolicies", () => {
-        const defaultEnforcementLevel: EnforcementLevel = "mandatory";
+        const defaultEnforcementLevel: EnforcementLevel = "advisory";
 
         const factories: Record<string, PolicyFactory<any>> = {
             ec2InstanceDetailedMonitoringEnabled: compute.ec2InstanceDetailedMonitoringEnabled,

--- a/src/tests/database.spec.ts
+++ b/src/tests/database.spec.ts
@@ -24,7 +24,13 @@ import { assertHasResourceViolation, assertNoResourceViolations, createResourceV
 
 describe("#redshiftClusterConfigurationCheck", () => {
     describe("encryption and logging must be enabled and node types specified", async () => {
-        const policy = database.redshiftClusterConfigurationCheck("mandatory", true, true, ["dc1.large", "test"]);
+        const policy = database.redshiftClusterConfigurationCheck({
+            enforcementLevel: "mandatory",
+            clusterDbEncrypted: true,
+            loggingEnabled: true,
+            nodeTypes: ["dc1.large", "test"],
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.redshift.Cluster, {
                 clusterIdentifier: "test",
@@ -84,7 +90,11 @@ describe("#redshiftClusterConfigurationCheck", () => {
     });
 
     describe("encryption and logging must be disabled and no nodeTypes specified", () => {
-        const policy = database.redshiftClusterConfigurationCheck("mandatory", false, false);
+        const policy = database.redshiftClusterConfigurationCheck({
+            enforcementLevel: "mandatory",
+            clusterDbEncrypted: false,
+            loggingEnabled: false,
+        });
 
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.redshift.Cluster, {
@@ -130,7 +140,13 @@ describe("#redshiftClusterConfigurationCheck", () => {
 
 describe("#redshiftClusterMaintenanceSettingsCheck", () => {
     describe("allVersionUpgrade required, preferred maintenance window and automate retention of 1", async () => {
-        const policy = database.redshiftClusterMaintenanceSettingsCheck("mandatory", true, "Mon:09:30-Mon:10:00", 1);
+        const policy = database.redshiftClusterMaintenanceSettingsCheck({
+            enforcementLevel: "mandatory",
+            allowVersionUpgrade: true,
+            preferredMaintenanceWindow: "Mon:09:30-Mon:10:00",
+            automatedSnapshotRetentionPeriod: 1,
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.redshift.Cluster, {
                 clusterIdentifier: "test",
@@ -187,7 +203,11 @@ describe("#redshiftClusterMaintenanceSettingsCheck", () => {
     });
 
     describe("preferred maintenance window and retention period not specified", async () => {
-        const policy = database.redshiftClusterMaintenanceSettingsCheck("mandatory", true);
+        const policy = database.redshiftClusterMaintenanceSettingsCheck({
+            enforcementLevel: "mandatory",
+            allowVersionUpgrade: true,
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.redshift.Cluster, {
                 clusterIdentifier: "test",
@@ -269,7 +289,13 @@ describe("#dynamodbTableEncryptionEnabled", () => {
 
 describe("#rdsInstanceBackupEnabled", () => {
     describe("retention period and window are specified, check read replicas", () => {
-        const policy = database.rdsInstanceBackupEnabled("mandatory", 7, "window", true);
+        const policy = database.rdsInstanceBackupEnabled({
+            enforcementLevel: "mandatory",
+            backupRetentionPeriod: 7,
+            preferredBackupWindow: "window",
+            checkReadReplicas: true,
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.rds.Instance, {
                 instanceClass: "db.m5.large",
@@ -316,7 +342,13 @@ describe("#rdsInstanceBackupEnabled", () => {
     });
 
     describe("do not check read replicas", () => {
-        const policy = database.rdsInstanceBackupEnabled("mandatory", 7, "window", false);
+        const policy = database.rdsInstanceBackupEnabled({
+            enforcementLevel: "mandatory",
+            backupRetentionPeriod: 7,
+            preferredBackupWindow: "window",
+            checkReadReplicas: false,
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.rds.Instance, {
                 instanceClass: "db.m5.large",
@@ -334,6 +366,7 @@ describe("#rdsInstanceBackupEnabled", () => {
 
     describe("do not specify a required backup period or window", () => {
         const policy = database.rdsInstanceBackupEnabled("mandatory");
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.rds.Instance, {
                 instanceClass: "db.m5.large",
@@ -365,8 +398,8 @@ describe("#rdsInstanceBackupEnabled", () => {
     describe("a poorly configure policy", () => {
         it("Should throw an error", () => {
             assert.throws(
-                () => { database.rdsInstanceBackupEnabled("mandatory", 0); },
-                "Specified retention period must be greater than 0.");
+                () => { database.rdsInstanceBackupEnabled({ backupRetentionPeriod: 0 }); },
+                "Specified retention period must be greater than 0");
         });
     });
 });
@@ -403,7 +436,11 @@ describe("#rdsInstancePublicAccessCheck", () => {
 
 describe("#rdsStorageEncrypted", () => {
     describe("kms key is specified", () => {
-        const policy = database.rdsStorageEncrypted("mandatory", "a-kms-key");
+        const policy = database.rdsStorageEncrypted({
+            enforcementLevel: "mandatory",
+            kmsKeyId: "a-kms-key",
+        });
+
         function getHappyPathArgs(): ResourceValidationArgs {
             return createResourceValidationArgs(aws.rds.Instance, {
                 instanceClass: "db.m5.large",

--- a/src/tests/security.spec.ts
+++ b/src/tests/security.spec.ts
@@ -34,7 +34,10 @@ import { ListAccessKeysRequest, ListMFADevicesRequest } from "aws-sdk/clients/ia
 
 describe("#iamAccessKeysRotated", () => {
     const maxKeyAge = 30;
-    const policy = security.iamAccessKeysRotated("mandatory", maxKeyAge);
+    const policy = security.iamAccessKeysRotated({
+        enforcementLevel: "mandatory",
+        maxKeyAge,
+    });
 
     const testAccessKeyId = "AKITESTKEYID";
     const testUserEmail = "test-user@example.com";

--- a/src/tests/util.spec.ts
+++ b/src/tests/util.spec.ts
@@ -1,0 +1,89 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+
+import "mocha";
+
+import { EnforcementLevel } from "@pulumi/policy";
+
+import { PolicyArgs } from "../policyArgs";
+import { getValueOrDefault, RequiredBy } from "../util";
+
+interface FooArgs extends PolicyArgs {
+    foo?: string;
+}
+
+describe("#getValueOrDefault", () => {
+    const def: RequiredBy<FooArgs, keyof PolicyArgs> = {
+        enforcementLevel: "mandatory",
+        foo: undefined,
+    };
+
+    it("returns defaults for undefined or null", () => {
+        assert.deepStrictEqual(getValueOrDefault(undefined, def), def);
+        assert.deepStrictEqual(getValueOrDefault(<FooArgs><unknown>null, def), def);
+    });
+
+    it("returns defaults for invalid enforcement level", () => {
+        assert.deepStrictEqual(getValueOrDefault(<EnforcementLevel>"invalidEnforcementLevel", def), def);
+    });
+
+    it("returns defaults with modified enforcement level as specified", () => {
+        const levels: EnforcementLevel[] = ["mandatory", "advisory", "disabled"];
+        for (const el of levels) {
+            assert.deepStrictEqual(getValueOrDefault(el, def), {
+                enforcementLevel: el,
+                foo: undefined,
+            });
+        }
+    });
+
+    it("returns defaults with modified foo as specified", () => {
+        assert.deepStrictEqual(getValueOrDefault({ foo: "bar" }, def), {
+            enforcementLevel: "mandatory",
+            foo: "bar",
+        });
+    });
+
+    it("returns enforcement level and foo as specified", () => {
+        assert.deepStrictEqual(getValueOrDefault({
+            enforcementLevel: "advisory",
+            foo: "bar",
+        }, def), {
+            enforcementLevel: "advisory",
+            foo: "bar",
+        });
+    });
+
+    it("returns defaults along with any extra props", () => {
+        assert.deepStrictEqual(getValueOrDefault(<FooArgs><unknown>{ bar: "blah" }, def), {
+            enforcementLevel: "mandatory",
+            foo: undefined,
+            bar: "blah",
+        });
+    });
+
+    it("returns enforcement level and foo as specified along with any extra props", () => {
+        assert.deepStrictEqual(getValueOrDefault(<FooArgs><unknown>{
+            enforcementLevel: "advisory",
+            foo: "bar",
+            bar: "blah",
+        }, def), {
+            enforcementLevel: "advisory",
+            foo: "bar",
+            bar: "blah",
+        });
+    });
+});

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "outDir": "bin",
+        "outDir": "../bin",
         "target": "es6",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -16,15 +16,22 @@
         "strictNullChecks": true
     },
     "files": [
-        "index.ts",
+        "awsGuard.ts",
         "compute.ts",
         "database.ts",
+        "elasticsearch.ts",
+        "enforcementLevel.ts",
+        "index.ts",
+        "policyArgs.ts",
         "security.ts",
         "storage.ts",
+        "tests/awsGuard.spec.ts",
         "tests/database.spec.ts",
         "tests/elasticsearch.spec.ts",
         "tests/security.spec.ts",
+        "tests/util.spec.ts",
         "tests/util.ts",
+        "util.ts",
         "version.ts"
     ]
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,45 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EnforcementLevel } from "@pulumi/policy";
+
+import { isEnforcementLevel } from "./enforcementLevel";
+import { PolicyArgs } from "./policyArgs";
+
+/** @internal */
+export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+/** @internal */
+export function getValueOrDefault<TArgs extends PolicyArgs>(
+    args: EnforcementLevel | TArgs | undefined,
+    def: RequiredBy<TArgs, keyof PolicyArgs>,
+): RequiredBy<TArgs, keyof PolicyArgs> {
+    const result = Object.assign({}, def);
+    if (!args) {
+        return result;
+    }
+    if (isEnforcementLevel(args)) {
+        result.enforcementLevel = args;
+        return result;
+    }
+    if (typeof args === "object") {
+        for (const p of Object.keys(args)) {
+            const v = (<any>args)[p];
+            if (v !== undefined) {
+                (<any>result)[p] = v;
+            }
+        }
+    }
+    return result;
+}


### PR DESCRIPTION
This provides a nicer way to create and configure the AWS Guard policies:

```typescript
const awsGuard = new AwsGuard();
```
The above is equivalent to:
```typescript
const awsGuard = new AwsGuard({ all: "advisory" });
```
To make all policies mandatory rather than advisory:
```typescript
const awsGuard = new AwsGuard({ all: "mandatory" });
```
To make all policies mandatory, but change a couple to be advisory:
```typescript
const awsGuard = new AwsGuard({
    all: "mandatory",
    ec2InstanceNoPublicIP: "advisory",
    elbAccessLoggingEnabled: "advisory",
});
```
To disable a particular policy:
```typescript
const awsGuard = new AwsGuard({
    ec2InstanceNoPublicIP: "disabled",
});
```
To disable all policies except ones explicitly enabled:
```typescript
const awsGuard = new AwsGuard({
    all: "disabled",
    ec2InstanceNoPublicIP: "mandatory",
    elbAccessLoggingEnabled: "mandatory",
});
```
To specify configuration for policies that have it:
```typescript
const awsGuard = new AwsGuard({
    ec2VolumeInUseCheck: { checkDeletion: false },
    encryptedVolumes: { enforcementLevel: "mandatory", kmsId: "id" },
    redshiftClusterMaintenanceSettingsCheck: { preferredMaintenanceWindow: "Mon:09:30-Mon:10:00" },
    acmCheckCertificateExpiration: { maxDaysUntilExpiration: 10 },
});