### PR TITLE
Finish up Elasticsearch rules

### DIFF
--- a/integration-tests/elasticsearch/index.ts
+++ b/integration-tests/elasticsearch/index.ts
@@ -46,8 +46,6 @@ switch (testScenario) {
         // Use the default VPC for the AWS account
         const defaultVpc = awsx.ec2.Vpc.getDefault();
 
-        console.log("Default VPC", defaultVpc);
-
         // Should update successful with a valid Elasticsearch domain!
         encryptedAtRestParam = {
             enabled: true,

--- a/src/elasticsearch.ts
+++ b/src/elasticsearch.ts
@@ -55,9 +55,6 @@ export function elasticsearchInVpcOnly(enforcementLevel?: EnforcementLevel): Res
             if (domain.vpcOptions === undefined) {
                 reportViolation(`Elasticsearch domain ${domain.domainName} must run within a VPC.`);
             }
-            // TODO: Do a more extensive check. We confirmed there is _any_ VPC associated with the ES Domain.
-            // But we could also add a separate rule to confirm that that VPC isn't internet addressable. Such
-            // as by checking if the subnets created have any rout table associations with an internet gateway.
         }),
     };
 }


### PR DESCRIPTION
Just making a final tweak to close out #9. We already wrote the rules, and had a lingering TODO. But thinking about it more, you don't want the Elasticsearch instance on the open internet... but some other resource (e.g. an EC2 VM) within the same VPC can be internet addressable without any problems. (And realistically, the Elasticsearch instance wouldn't be of much use otherwise!)

Fixes #9 